### PR TITLE
CI: Give PR SemVer Bump write permissions for 1.7.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,10 @@ updates:
       timezone: "America/Chicago"
       time: "22:00"
       interval: daily
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
+    directory: "/"
+    schedule:
+      interval: daily

--- a/.github/workflows/ci-main.yaml
+++ b/.github/workflows/ci-main.yaml
@@ -13,6 +13,7 @@ jobs:
   bump-tag-version:
     name: Bump and Tag Version
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
     - uses: actions/checkout@v4
       name: Checkout


### PR DESCRIPTION
# Release Notes:
- Give PR SemVer Bump write permissions for 1.7.0
- Register GitHub actions for @dependabot updates
<sub>_End Release Notes_</sub>