### PR TITLE
Update the workflow for deletions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   # Enable version updates for nuget
-  - package-ecosystem: "nuget"
+  - package-ecosystem: nuget
     # Look for NuGet dependency info from the `root` directory
     directory: "/"
     registries: "*"
@@ -18,5 +18,8 @@ updates:
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
     directory: "/"
+    commit-message:
+      include: scope
+      prefix: ":arrow_up: "
     schedule:
       interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,4 +22,6 @@ updates:
       include: scope
       prefix: ":arrow_up: "
     schedule:
+      timezone: "America/Chicago"
+      time: "22:00"
       interval: daily

--- a/.github/workflows/ci-cleanup.yaml
+++ b/.github/workflows/ci-cleanup.yaml
@@ -13,7 +13,7 @@ on:
       delete_run_by_conclusion_pattern:
         description: 'Remove workflow by conclusion: action_required, cancelled, failure, skipped, success'
         required: true
-        default: "All"
+        default: "skipped"
         type: choice
         options:
           - cancelled
@@ -21,10 +21,16 @@ on:
           - skipped
       dry_run:
         description: 'Only log actions, do not perform any delete operations.'
-        required: false
+        required: true
+        type: choice
+        default: "true"
+        options:
+          - "true"
+          - "false"
 
 jobs:
   del_runs:
+    name: Delete Undesirable Runs
     runs-on: ubuntu-latest
     steps:
       - name: Delete workflow runs

--- a/.github/workflows/ci-main.yaml
+++ b/.github/workflows/ci-main.yaml
@@ -1,4 +1,4 @@
-name: "Continous Integration: Releases"
+name: "Continuous Integration: Releases"
 
 on:
   push:

--- a/.github/workflows/ci-pull-request-autoapprove-bot.yaml
+++ b/.github/workflows/ci-pull-request-autoapprove-bot.yaml
@@ -20,7 +20,6 @@ permissions:
   contents: read
   pull-requests: write
 
-
 concurrency: 
   group: Auto-Approve-${{ github.ref_name }}
   cancel-in-progress: true
@@ -61,5 +60,6 @@ jobs:
     if: ${{ needs.check-pr.outputs.semver_skipped == 'false' }} && (github.actor == 'dependabot[bot]' || github.actor == 'BardezAnAvatar')
     steps:
       - uses: hmarr/auto-approve-action@v4
+        name: Auto-Approval
         env:
           review-message: "Bot auto-approved PR"

--- a/.github/workflows/ci-pull-request-autoapprove-bot.yaml
+++ b/.github/workflows/ci-pull-request-autoapprove-bot.yaml
@@ -22,7 +22,7 @@ permissions:
 
 
 concurrency: 
-  group: ${{ github.ref_name }}
+  group: Auto-Approve-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci-pull-request-autoapprove-bot.yaml
+++ b/.github/workflows/ci-pull-request-autoapprove-bot.yaml
@@ -1,4 +1,4 @@
-name: "Continous Integration: Auto-Approve PRs"
+name: "Continuous Integration: Auto-Approve PRs"
 
 on:
   pull_request:

--- a/.github/workflows/ci-pull-request.yaml
+++ b/.github/workflows/ci-pull-request.yaml
@@ -14,7 +14,7 @@ on:
     # - edited #updating PR title, body, state or base?
 
 concurrency: 
-  group: ${{ github.ref_name }}
+  group: PR-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci-pull-request.yaml
+++ b/.github/workflows/ci-pull-request.yaml
@@ -1,4 +1,4 @@
-name: "Continous Integration: PRs"
+name: "Continuous Integration: PRs"
 
 on:
   pull_request:


### PR DESCRIPTION
# Release Notes:
- Update the workflow for deleting old, undesired runs
     - Force Dry run to be default, and a required option
- Make the workflows distinct groupings for cancellations due to newer runs:
     - `Contin(u)ous Integration: PRs`
     - `Contin(u)ous Integration: Releases`
     - `Contin(u)ous Integration: Auto-Arrpove PRs`
- Fix typo in `Contin(u)ous` naming of workflows
- Update @dependabot's timing for GitHub actions as well as naming patterns for PRs
<sub>_End Release Notes_</sub>