### PR TITLE
CI: Make `dry_run` configuration optional so it will actually run

### DIFF
--- a/.github/workflows/ci-cleanup.yaml
+++ b/.github/workflows/ci-cleanup.yaml
@@ -21,12 +21,12 @@ on:
           - skipped
       dry_run:
         description: 'Only log actions, do not perform any delete operations.'
-        required: true
+        required: false
         type: choice
         default: "true"
         options:
           - "true"
-          - "false"
+          - ""
 
 jobs:
   del_runs:


### PR DESCRIPTION
# Release Notes:
- CI: Make `dry_run` configuration optional so it will actually run
<sub>_End Release Notes_</sub>